### PR TITLE
修复了一个“视频文件不存在”的bug

### DIFF
--- a/exAudio.py
+++ b/exAudio.py
@@ -58,7 +58,9 @@ def process_audio_split(name):
     # 生成唯一文件夹名，并依次调用转换和分割函数
     folder_name = time.strftime('%Y%m%d%H%M%S')
     convert_flv_to_mp3(name, target_name=folder_name)
-    conv_dir = f"audio/conv/{folder_name}"
-    split_mp3(conv_dir, folder_name)
+    conv_path = f"audio/conv/{folder_name}.mp3"
+    if not os.path.exists(conv_path):
+        raise FileNotFoundError(f"转换后的音频文件不存在: {conv_path}")
+    split_mp3(conv_path, folder_name)
     return folder_name
 

--- a/exAudio.py
+++ b/exAudio.py
@@ -18,9 +18,20 @@ def check_video_integrity(file_path):
     return True
 
 def convert_flv_to_mp3(name, target_name=None, folder='bilibili_video'):
-    input_path = f'{folder}/{name}.mp4'  
+    # 先尝试直接拼接 .mp4
+    input_path = f'{folder}/{name}.mp4'
     if not os.path.exists(input_path):
-        raise FileNotFoundError(f"视频文件不存在: {input_path}")
+        # 如果不存在，尝试在文件夹下查找视频文件
+        dir_path = f'{folder}/{name}'
+        if os.path.isdir(dir_path):
+            for file in os.listdir(dir_path):
+                if file.endswith(('.mp4', '.flv', '.mkv', '.avi')):
+                    input_path = os.path.join(dir_path, file)
+                    break
+            else:
+                raise FileNotFoundError(f"目录下未找到视频文件: {dir_path}")
+        else:
+            raise FileNotFoundError(f"视频文件不存在: {input_path}")
     if not check_video_integrity(input_path):
         raise ValueError(f"视频文件损坏: {input_path}")
     # 提取视频中的音频并保存为 MP3 到 audio/conv 目录


### PR DESCRIPTION
我在下载https://www.bilibili.com/video/BV19x9uYsE6B?spm_id_from=333.788.videopod.sections&vd_source=1d782cc1c7f7294f85b3e9b56f6ac1c7  视频时，出现了如下错误。发现下载其他视频会报同样的错误。查看目录后我发现视频确实正确下载到了正确的位置上，并且可以播放，但是后面的步骤就进行不了了。定位到日志信息后做出了修改，现在新的逻辑是如果找不到，那就找第一个视频。修改以后成功解决了问题。
<img width="887" height="971" alt="问题截图1" src="https://github.com/user-attachments/assets/0b1cc6d3-a417-42a2-ac2f-7d8efa383673" />
<img width="843" height="1078" alt="问题截图2" src="https://github.com/user-attachments/assets/e5ac4082-df3d-4b41-bfaa-db1bcc2af6d4" />
