### PR TITLE
fix: use utf-8 encoding for subprocess output on Windows

### DIFF
--- a/src/b2t/bootstrap.py
+++ b/src/b2t/bootstrap.py
@@ -54,7 +54,7 @@ def sync_selected_environment(
     if not uv_available(which):
         return BootstrapEnvironmentResult(ok=False, reason="missing_uv", command=command)
     assert runner is not None
-    completed = runner(command, cwd=workspace, capture_output=True, text=True, check=False)
+    completed = runner(command, cwd=workspace, capture_output=True, encoding="utf-8", check=False)
     return BootstrapEnvironmentResult(
         ok=completed.returncode == 0,
         reason="ok" if completed.returncode == 0 else "sync_failed",

--- a/src/b2t/pipeline.py
+++ b/src/b2t/pipeline.py
@@ -125,7 +125,7 @@ class B2TPipeline:
                     str(audio_path),
                 ],
                 capture_output=True,
-                text=True,
+                encoding="utf-8",
             )
             if result.returncode != 0:
                 stderr = result.stderr.strip() or "unknown ffmpeg error"
@@ -160,7 +160,7 @@ class B2TPipeline:
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            encoding="utf-8",
         )
         assert process.stdout is not None
         for line in process.stdout:
@@ -229,7 +229,7 @@ def _probe_media_duration_seconds(video_path: Path) -> float | None:
             str(video_path),
         ],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
     )
     if result.returncode != 0:
         return None


### PR DESCRIPTION
## 中文描述

### 问题描述

- 将所有 `subprocess.run` / `Popen` 调用中的 `text=True`（中文 Windows 上默认为 GBK 编码）替换为 `encoding="utf-8"`
- 修复了 ffmpeg 输出包含非 GBK 字节时出现的 `'gbk' codec can't decode byte 0xaf` 错误

### 根因分析

在中文 Windows 上，Python 的 `subprocess` 使用 `text=True` 时会采用系统默认编码（GBK/CP936）。当 ffmpeg 输出的内容包含 GBK 范围外的字符（如进度符号、特殊 Unicode 字符）时，Python 会抛出异常：

```
'gbk' codec can't decode byte 0xaf in position 3231: illegal multibyte sequence
```

该错误在 `提取音频`（音频提取）阶段，约 55% 进度时出现。

### 修改内容

| 文件 | 修改说明 |
|------|---------|
| `src/b2t/pipeline.py` | 3 处 subprocess 调用：ffmpeg 音频提取（带/不带进度条）、ffprobe 媒体时长探测 |
| `src/b2t/bootstrap.py` | 1 处 subprocess 调用：uv sync 环境引导 |

全部 `text=True` → `encoding="utf-8"`。

### 测试计划

- [x] 在中文 Windows 上运行 `bili2text tx <bilibili_url>` — 音频提取阶段应正常完成，不再报编码错误
- [x] 在中文 Windows 上运行 `bili2text bootstrap` — uv sync 输出应正常显示

### 相关错误

修复了以下错误：`'gbk' codec can't decode byte 0xaf in position 3231: illegal multibyte sequence`

---

## English Description

## Summary

- Replace `text=True` (which defaults to GBK on Chinese Windows) with `encoding="utf-8"` in all `subprocess.run` / `Popen` calls
- Fixes `'gbk' codec can't decode byte 0xaf` error that occurs during audio extraction when ffmpeg outputs non-GBK bytes

## Root Cause

On Chinese Windows, Python's `subprocess` with `text=True` uses the system's default encoding (GBK/CP936). When ffmpeg outputs characters outside the GBK range (e.g., progress symbols, special Unicode chars), Python raises:

```
'gbk' codec can't decode byte 0xaf in position 3231: illegal multibyte sequence
```

This error surfaced at the `提取音频` (audio extraction) stage, ~55% progress.

## Changes

| File | Change |
|------|--------|
| `src/b2t/pipeline.py` | 3 subprocess calls: `ffmpeg` audio extraction (with & without progress), `ffprobe` duration probe |
| `src/b2t/bootstrap.py` | 1 subprocess call: `uv sync` environment bootstrap |

All `text=True` → `encoding="utf-8"`.

## Test Plan

- [x] Run `bili2text tx <bilibili_url>` on Chinese Windows — audio extraction should complete without encoding errors
- [x] Run `bili2text bootstrap` on Chinese Windows — uv sync output should display correctly

## Related Issue

Fixes encoding error: `'gbk' codec can't decode byte 0xaf in position 3231: illegal multibyte sequence`
