### PR TITLE
feat: support downloading single part from multi-part Bilibili videos

### DIFF
--- a/src/b2t/downloaders/ytdlp.py
+++ b/src/b2t/downloaders/ytdlp.py
@@ -30,18 +30,7 @@ class YtDlpDownloader(Downloader):
                 "yt-dlp is not installed. Run `uv sync` to install the core dependencies."
             ) from exc
 
-        ydl_opts: dict[str, Any] = {
-            "format": "bv*+ba/b",
-            "merge_output_format": "mp4",
-            "noplaylist": True,
-            "outtmpl": str(settings.downloads_dir / "%(id)s.%(playlist_index)02d.%(ext)s"),
-            "noprogress": True,
-            "quiet": True,
-            "no_warnings": True,
-        }
-        if source.page is not None:
-            ydl_opts["playlist_items"] = str(source.page)
-            ydl_opts["noplaylist"] = False
+        ydl_opts = self._build_ydl_opts(source, settings)
         if progress is not None:
             def progress_hook(data: dict[str, Any]) -> None:
                 status = data.get("status")
@@ -83,6 +72,22 @@ class YtDlpDownloader(Downloader):
                 "webpage_url": info.get("webpage_url") or source.url,
             },
         )
+
+    def _build_ydl_opts(self, source: SourceRef, settings: Settings) -> dict[str, Any]:
+        ydl_opts: dict[str, Any] = {
+            "format": "bv*+ba/b",
+            "merge_output_format": "mp4",
+            "noplaylist": True,
+            "outtmpl": str(settings.downloads_dir / "%(id)s.%(ext)s"),
+            "noprogress": True,
+            "quiet": True,
+            "no_warnings": True,
+        }
+        if source.page is not None:
+            ydl_opts["playlist_items"] = str(source.page)
+            ydl_opts["noplaylist"] = False
+            ydl_opts["outtmpl"] = str(settings.downloads_dir / "%(id)s.%(playlist_index)02d.%(ext)s")
+        return ydl_opts
 
     def _resolve_video_path(self, ydl: Any, info: dict[str, Any]) -> Path:
         requested_downloads = info.get("requested_downloads") or []

--- a/src/b2t/downloaders/ytdlp.py
+++ b/src/b2t/downloaders/ytdlp.py
@@ -34,11 +34,14 @@ class YtDlpDownloader(Downloader):
             "format": "bv*+ba/b",
             "merge_output_format": "mp4",
             "noplaylist": True,
-            "outtmpl": str(settings.downloads_dir / "%(id)s.%(ext)s"),
+            "outtmpl": str(settings.downloads_dir / "%(id)s.%(playlist_index)02d.%(ext)s"),
             "noprogress": True,
             "quiet": True,
             "no_warnings": True,
         }
+        if source.page is not None:
+            ydl_opts["playlist_items"] = str(source.page)
+            ydl_opts["noplaylist"] = False
         if progress is not None:
             def progress_hook(data: dict[str, Any]) -> None:
                 status = data.get("status")

--- a/src/b2t/inputs.py
+++ b/src/b2t/inputs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qs, urlparse
 
 from b2t.models import SourceRef
 
@@ -64,13 +64,14 @@ def _looks_like_url(value: str) -> bool:
 
 
 def _extract_page_from_url(url: str) -> int | None:
-    """Extract 'p' (page) parameter from URL query string."""
+    """Extract a valid 1-based 'p' (page) parameter from URL query string."""
     parsed = urlparse(url)
     query_params = parse_qs(parsed.query)
     p_values = query_params.get("p", [])
     if p_values:
         try:
-            return int(p_values[0])
+            page = int(p_values[0])
         except ValueError:
             return None
+        return page if page >= 1 else None
     return None

--- a/src/b2t/inputs.py
+++ b/src/b2t/inputs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 from b2t.models import SourceRef
 
@@ -40,12 +40,14 @@ def parse_source(raw_input: str) -> SourceRef:
     if match:
         bv = match.group(1)
         url = value if _looks_like_url(value) else f"https://www.bilibili.com/video/{bv}"
+        page = _extract_page_from_url(url)
         return SourceRef(
             raw_input=value,
             kind="bilibili",
             display_name=bv,
             url=url,
             bv=bv,
+            page=page,
         )
 
     raise ValueError("source must be a BV id, a Bilibili URL, or an existing local audio/video file")
@@ -59,3 +61,16 @@ def safe_stem(value: str) -> str:
 def _looks_like_url(value: str) -> bool:
     parsed = urlparse(value)
     return bool(parsed.scheme and parsed.netloc)
+
+
+def _extract_page_from_url(url: str) -> int | None:
+    """Extract 'p' (page) parameter from URL query string."""
+    parsed = urlparse(url)
+    query_params = parse_qs(parsed.query)
+    p_values = query_params.get("p", [])
+    if p_values:
+        try:
+            return int(p_values[0])
+        except ValueError:
+            return None
+    return None

--- a/src/b2t/models.py
+++ b/src/b2t/models.py
@@ -18,6 +18,7 @@ class SourceRef:
     url: str | None = None
     bv: str | None = None
     path: Path | None = None
+    page: int | None = None
 
 
 @dataclass(slots=True)

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from b2t.inputs import parse_source, safe_stem
 
 
@@ -22,14 +24,21 @@ def test_parse_bilibili_url_extracts_page_number() -> None:
     assert source.page == 2
 
 
-def test_parse_bilibili_url_without_page_has_none_page() -> None:
+def test_parse_bilibili_url_without_page_sets_page_to_none() -> None:
     source = parse_source("https://www.bilibili.com/video/BV1xx411c7XD")
     assert source.kind == "bilibili"
     assert source.page is None
 
 
-def test_parse_bv_identifier_without_page_has_none_page() -> None:
+def test_parse_bv_identifier_without_page_sets_page_to_none() -> None:
     source = parse_source("BV1xx411c7XD")
+    assert source.kind == "bilibili"
+    assert source.page is None
+
+
+@pytest.mark.parametrize("page", ["0", "-1", "not-a-number"])
+def test_parse_bilibili_url_ignores_invalid_page_number(page: str) -> None:
+    source = parse_source(f"https://www.bilibili.com/video/BV1xx411c7XD?p={page}")
     assert source.kind == "bilibili"
     assert source.page is None
 

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -16,6 +16,24 @@ def test_parse_bilibili_url_keeps_page_information() -> None:
     assert source.url == "https://www.bilibili.com/video/BV1xx411c7XD?p=2"
 
 
+def test_parse_bilibili_url_extracts_page_number() -> None:
+    source = parse_source("https://www.bilibili.com/video/BV1xx411c7XD?p=2")
+    assert source.kind == "bilibili"
+    assert source.page == 2
+
+
+def test_parse_bilibili_url_without_page_has_none_page() -> None:
+    source = parse_source("https://www.bilibili.com/video/BV1xx411c7XD")
+    assert source.kind == "bilibili"
+    assert source.page is None
+
+
+def test_parse_bv_identifier_without_page_has_none_page() -> None:
+    source = parse_source("BV1xx411c7XD")
+    assert source.kind == "bilibili"
+    assert source.page is None
+
+
 def test_parse_local_audio_file(tmp_path: Path) -> None:
     audio_path = tmp_path / "sample.wav"
     audio_path.write_bytes(b"wav")

--- a/tests/test_ytdlp_downloader.py
+++ b/tests/test_ytdlp_downloader.py
@@ -1,0 +1,38 @@
+from b2t.config import Settings
+from b2t.downloaders.ytdlp import YtDlpDownloader
+from b2t.models import SourceRef
+
+
+def test_ytdlp_options_keep_single_video_output_template_by_default(tmp_path) -> None:
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert opts["noplaylist"] is True
+    assert "playlist_items" not in opts
+    assert opts["outtmpl"] == str(settings.downloads_dir / "%(id)s.%(ext)s")
+
+
+def test_ytdlp_options_select_playlist_item_when_page_is_set(tmp_path) -> None:
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="https://www.bilibili.com/video/BV1xx411c7XD?p=2",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD?p=2",
+        page=2,
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert opts["noplaylist"] is False
+    assert opts["playlist_items"] == "2"
+    assert opts["outtmpl"] == str(settings.downloads_dir / "%(id)s.%(playlist_index)02d.%(ext)s")


### PR DESCRIPTION
When a Bilibili URL contains ?p=N parameter, only that specific part will be downloaded instead of the entire collection.

Changes:
- Add `page` field to SourceRef model to store the part number
- Extract `p` parameter from URL in parse_source function
- Configure yt-dlp to use playlist_items when page is specified
- Add unit tests for page extraction behavior