### PR TITLE
fix: volcengine transcriber use flash API with correct headers

### DIFF
--- a/src/b2t/transcribers/volcengine.py
+++ b/src/b2t/transcribers/volcengine.py
@@ -64,7 +64,7 @@ class VolcengineFlashTranscriber(Transcriber):
 
         audio_data = base64.b64encode(audio_path.read_bytes()).decode("utf-8")
         payload: dict[str, Any] = {
-            "user": {"uid": "bili2text"},
+            "user": {"uid": self._user_uid()},
             "audio": {
                 "format": audio_path.suffix.lstrip(".").lower() or "wav",
                 "data": audio_data,
@@ -134,3 +134,6 @@ class VolcengineFlashTranscriber(Transcriber):
                 "Content-Type": "application/json",
             }
         return {}
+
+    def _user_uid(self) -> str:
+        return self.api_key or self.app_key

--- a/src/b2t/transcribers/volcengine.py
+++ b/src/b2t/transcribers/volcengine.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import base64
+import uuid
 from pathlib import Path
 from typing import Any
 
 from b2t.i18n import dependency_sync_guidance
 from b2t.transcribers.base import Transcriber
+
+# 极速版API：同步返回，支持base64音频
+FLASH_URL = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"
 
 
 class VolcengineFlashTranscriber(Transcriber):
@@ -45,19 +49,30 @@ class VolcengineFlashTranscriber(Transcriber):
                 f"{dependency_sync_guidance('en-US')}"
             ) from exc
 
-        headers = self._build_headers()
-        if not headers:
+        auth_headers = self._build_headers()
+        if not auth_headers:
             raise RuntimeError("Volcengine provider requires API credentials. Run `bili2text bootstrap` first.")
 
+        task_id = str(uuid.uuid4())
+
+        headers = {
+            **auth_headers,
+            "X-Api-Resource-Id": self.resource_id,
+            "X-Api-Request-Id": task_id,
+            "X-Api-Sequence": "-1",
+        }
+
         audio_data = base64.b64encode(audio_path.read_bytes()).decode("utf-8")
-        payload = {
+        payload: dict[str, Any] = {
             "user": {"uid": "bili2text"},
-            "audio": {"format": audio_path.suffix.lstrip(".").lower() or "wav", "data": audio_data},
+            "audio": {
+                "format": audio_path.suffix.lstrip(".").lower() or "wav",
+                "data": audio_data,
+            },
             "request": {
                 "model_name": self.model_name,
                 "show_utterances": True,
                 "enable_itn": self.use_itn,
-                "result_type": "full",
             },
         }
 
@@ -65,16 +80,36 @@ class VolcengineFlashTranscriber(Transcriber):
             payload["request"]["context"] = prompt
 
         response = requests.post(
-            f"https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit?resource_id={self.resource_id}",
+            FLASH_URL,
             headers=headers,
             json=payload,
             timeout=300,
         )
-        response.raise_for_status()
-        data = response.json()
-        if data.get("code") != 0:
-            raise RuntimeError(f"Volcengine request failed: {data.get('message') or data}")
 
+        # 检查 HTTP 层面错误
+        if response.status_code != 200:
+            response.raise_for_status()
+
+        # 检查业务状态码（在 response header 中）
+        status_code = response.headers.get("X-Api-Status-Code", "")
+        status_msg = response.headers.get("X-Api-Message", "")
+
+        if status_code == "20000003":
+            # 静音音频
+            return {
+                "text": "",
+                "segments": [],
+                "language": None,
+                "model": self.model_name,
+                "raw_response": {},
+            }
+
+        if status_code != "20000000":
+            raise RuntimeError(
+                f"Volcengine recognize failed: [{status_code}] {status_msg}"
+            )
+
+        data = response.json()
         result = data.get("result", {})
         utterances = result.get("utterances") or []
         text = "\n".join(item.get("text", "") for item in utterances if item.get("text")).strip()
@@ -84,7 +119,7 @@ class VolcengineFlashTranscriber(Transcriber):
         return {
             "text": text,
             "segments": utterances,
-            "language": result.get("language"),
+            "language": None,
             "model": self.model_name,
             "raw_response": data,
         }

--- a/tests/test_volcengine.py
+++ b/tests/test_volcengine.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+from b2t.transcribers.volcengine import FLASH_URL, VolcengineFlashTranscriber
+
+
+class FakeResponse:
+    status_code = 200
+    headers = {
+        "X-Api-Status-Code": "20000000",
+        "X-Api-Message": "OK",
+    }
+
+    def json(self) -> dict[str, Any]:
+        return {
+            "result": {
+                "text": "hello",
+                "utterances": [{"text": "hello"}],
+            }
+        }
+
+
+def test_volcengine_flash_uses_api_key_as_user_uid(tmp_path, monkeypatch) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"audio")
+    calls: list[dict[str, Any]] = []
+
+    def post(
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        timeout: int,
+    ) -> FakeResponse:
+        calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=post))
+
+    result = VolcengineFlashTranscriber(api_key=" app-key ").transcribe(audio_path)
+
+    assert result["text"] == "hello"
+    assert calls[0]["url"] == FLASH_URL
+    assert calls[0]["headers"]["X-Api-Key"] == "app-key"
+    assert calls[0]["json"]["user"]["uid"] == "app-key"
+
+
+def test_volcengine_flash_uses_legacy_app_key_as_user_uid(tmp_path, monkeypatch) -> None:
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"audio")
+    calls: list[dict[str, Any]] = []
+
+    def post(
+        url: str,
+        *,
+        headers: dict[str, str],
+        json: dict[str, Any],
+        timeout: int,
+    ) -> FakeResponse:
+        calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return FakeResponse()
+
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(post=post))
+
+    transcriber = VolcengineFlashTranscriber(app_key=" legacy-app ", access_key=" access-token ")
+    result = transcriber.transcribe(audio_path)
+
+    assert result["text"] == "hello"
+    assert calls[0]["headers"]["X-Api-App-Key"] == "legacy-app"
+    assert calls[0]["headers"]["X-Api-Access-Key"] == "access-token"
+    assert calls[0]["json"]["user"]["uid"] == "legacy-app"


### PR DESCRIPTION
- Use flash endpoint /auc/bigmodel/recognize/flash instead of /auc/bigmodel/submit
- Move resource_id from URL query param to X-Api-Resource-Id header
- Add required headers: X-Api-Request-Id (UUID), X-Api-Sequence (-1)
- Fix status code check: read X-Api-Status-Code from response header instead of 'code' field from response body
- Remove invalid 'result_type: full' field from payload

follow the official api document: https://www.volcengine.com/docs/6561/1631584?lang=zh