### PR TITLE
yt-dlp: 添加 cookie 支持和代理绕过功能

### DIFF
--- a/src/b2t/downloaders/ytdlp.py
+++ b/src/b2t/downloaders/ytdlp.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -83,6 +84,23 @@ class YtDlpDownloader(Downloader):
             "quiet": True,
             "no_warnings": True,
         }
+
+        # Support cookies for authenticated access to Bilibili.
+        # Priority: B2T_COOKIE_FILE env var > cookies.txt in workspace.
+        cookie_file = os.getenv("B2T_COOKIE_FILE")
+        if cookie_file:
+            cookie_path = Path(cookie_file).expanduser()
+        else:
+            cookie_path = settings.workspace_root / "cookies.txt"
+        if cookie_path.exists():
+            ydl_opts["cookiefile"] = str(cookie_path)
+
+        # Bilibili's CDN frequently blocks proxy/VPN nodes, causing 412
+        # or SSL errors. Direct connections usually work better.
+        # Set B2T_USE_PROXY=1 to re-enable the system proxy if needed.
+        if not os.getenv("B2T_USE_PROXY"):
+            ydl_opts["noproxy"] = True
+
         if source.page is not None:
             ydl_opts["playlist_items"] = str(source.page)
             ydl_opts["noplaylist"] = False

--- a/src/b2t/downloaders/ytdlp.py
+++ b/src/b2t/downloaders/ytdlp.py
@@ -98,8 +98,9 @@ class YtDlpDownloader(Downloader):
         # Bilibili's CDN frequently blocks proxy/VPN nodes, causing 412
         # or SSL errors. Direct connections usually work better.
         # Set B2T_USE_PROXY=1 to re-enable the system proxy if needed.
-        if not os.getenv("B2T_USE_PROXY"):
-            ydl_opts["noproxy"] = True
+        use_proxy = os.getenv("B2T_USE_PROXY", "").strip().lower() in {"1", "true", "yes", "on"}
+        if not use_proxy:
+            ydl_opts["proxy"] = ""
 
         if source.page is not None:
             ydl_opts["playlist_items"] = str(source.page)

--- a/tests/test_ytdlp_downloader.py
+++ b/tests/test_ytdlp_downloader.py
@@ -36,3 +36,51 @@ def test_ytdlp_options_select_playlist_item_when_page_is_set(tmp_path) -> None:
     assert opts["noplaylist"] is False
     assert opts["playlist_items"] == "2"
     assert opts["outtmpl"] == str(settings.downloads_dir / "%(id)s.%(playlist_index)02d.%(ext)s")
+
+
+def test_ytdlp_options_bypass_proxy_by_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("B2T_USE_PROXY", raising=False)
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert opts["proxy"] == ""
+
+
+def test_ytdlp_options_keep_system_proxy_when_enabled(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("B2T_USE_PROXY", "1")
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert "proxy" not in opts
+
+
+def test_ytdlp_options_falsey_proxy_flag_still_bypasses(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("B2T_USE_PROXY", "0")
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert opts["proxy"] == ""


### PR DESCRIPTION
Closes #82

## 简介

为 yt-dlp 下载器添加两个功能，提升 Bilibili 访问的稳定性：

1. **Cookie 文件自动检测** — 如果工作目录下存在 `cookies.txt`（或设置了 `B2T_COOKIE_FILE` 环境变量），会自动传递给 yt-dlp，用于需要登录才能访问的视频。

2. **默认绕过系统代理** — 代理/VPN（如 Clash Verge）的节点经常被 Bilibili CDN 封锁，导致 HTTP 412 或 SSL 错误。直连通常更稳定，因此默认关闭代理。如需使用代理，设置 `B2T_USE_PROXY=1` 即可恢复。

## 问题背景

国内用户在使用 Clash Verge 等代理软件时，经常遇到以下错误而无法下载 Bilibili 视频：

```
ERROR: [BiliBili] BV...: Unable to download webpage: HTTP Error 412: Precondition Failed
```

根本原因是 Bilibili 的反爬虫系统会拦截代理节点的请求。由于直连 Bilibili 对大多数用户来说是稳定可用的，默认绕过代理可以避免这个问题。

## 改动内容

- `src/b2t/downloaders/ytdlp.py` — `_build_ydl_opts` 方法新增 18 行
- Cookie 路径优先级：`$B2T_COOKIE_FILE` > `$WORKSPACE/cookies.txt`
- 代理绕过：默认开启，通过 `B2T_USE_PROXY=1` 可恢复使用系统代理