### PR TITLE
feat: add --cookies-from-browser support for bypassing Bilibili 412

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "rich>=13.9.4",
   "tqdm>=4.67.3",
   "typer>=0.12.5",
-  "yt-dlp>=2025.3.31",
+  "yt-dlp>=2026.6.9",
 ]
 
 [project.optional-dependencies]

--- a/src/b2t/cli.py
+++ b/src/b2t/cli.py
@@ -49,6 +49,12 @@ def create_app(language: str = DEFAULT_LANGUAGE) -> typer.Typer:
         prompt: str = typer.Option("", "--prompt", help=tr(language, "opt_prompt_help")),
         output: Path | None = typer.Option(None, "--output", help=tr(language, "opt_output_help")),
         workspace: Path | None = typer.Option(None, "--workspace", help=tr(language, "opt_workspace_help")),
+        cookies_from_browser: str | None = typer.Option(
+            None,
+            "--cookies-from-browser",
+            "-C",
+            help=tr(language, "opt_cookies_from_browser_help"),
+        ),
     ) -> None:
         """Download or open media, then transcribe it with the selected provider."""
         try:
@@ -59,6 +65,7 @@ def create_app(language: str = DEFAULT_LANGUAGE) -> typer.Typer:
                 config=config,
                 provider=provider,
                 model=model,
+                cookies_from_browser=cookies_from_browser,
             )
             task = service.submit_transcription(
                 source=source,
@@ -91,6 +98,12 @@ def create_app(language: str = DEFAULT_LANGUAGE) -> typer.Typer:
         model: str | None = typer.Option(None, "--model", help=tr(language, "opt_model_help")),
         prompt: str = typer.Option("", "--prompt", help=tr(language, "opt_prompt_help")),
         workspace: Path | None = typer.Option(None, "--workspace", help=tr(language, "opt_workspace_help")),
+        cookies_from_browser: str | None = typer.Option(
+            None,
+            "--cookies-from-browser",
+            "-C",
+            help=tr(language, "opt_cookies_from_browser_help"),
+        ),
     ) -> None:
         """Submit multiple transcription tasks from arguments or a newline-separated file."""
         selected_language = _detect_preferred_language(workspace)
@@ -101,6 +114,7 @@ def create_app(language: str = DEFAULT_LANGUAGE) -> typer.Typer:
                 config=config,
                 provider=provider,
                 model=model,
+                cookies_from_browser=cookies_from_browser,
             )
             source_values = _collect_batch_sources(sources or [], source_file)
             tasks = [
@@ -341,6 +355,7 @@ def _build_task_service(
     config: AppConfig,
     provider: str | None = None,
     model: str | None = None,
+    cookies_from_browser: str | None = None,
 ) -> TaskService:
     database = AppDatabase(settings)
     library = WorkspaceLibrary(settings, database)
@@ -352,6 +367,7 @@ def _build_task_service(
             config=config,
             provider=selected_provider or provider or config.default_provider,
             model=selected_model or model or config.default_model,
+            cookies_from_browser=cookies_from_browser,
         ),
     )
     service.ensure_indexed()

--- a/src/b2t/downloaders/ytdlp.py
+++ b/src/b2t/downloaders/ytdlp.py
@@ -12,6 +12,9 @@ from b2t.models import DownloadResult, SourceRef
 class YtDlpDownloader(Downloader):
     name = "yt-dlp"
 
+    def __init__(self, cookies_from_browser: str | None = None) -> None:
+        self.cookies_from_browser = cookies_from_browser
+
     def download(
         self,
         source: SourceRef,
@@ -94,6 +97,14 @@ class YtDlpDownloader(Downloader):
             cookie_path = settings.workspace_root / "cookies.txt"
         if cookie_path.exists():
             ydl_opts["cookiefile"] = str(cookie_path)
+
+        # --cookies-from-browser extracts live cookies directly from a
+        # browser profile, which is more reliable than a static cookies.txt
+        # for bypassing Bilibili's anti-bot (WBI) checks.
+        # Priority: constructor arg > B2T_COOKIES_FROM_BROWSER env var.
+        cfbr = self.cookies_from_browser or os.getenv("B2T_COOKIES_FROM_BROWSER")
+        if cfbr:
+            ydl_opts["cookiesfrombrowser"] = (cfbr,)
 
         # Bilibili's CDN frequently blocks proxy/VPN nodes, causing 412
         # or SSL errors. Direct connections usually work better.

--- a/src/b2t/factory.py
+++ b/src/b2t/factory.py
@@ -15,6 +15,7 @@ def build_pipeline(
     config: AppConfig,
     provider: str | None = None,
     model: str | None = None,
+    cookies_from_browser: str | None = None,
 ) -> B2TPipeline:
     selected_provider = (provider or config.default_provider).strip().lower()
     selected_model = (model or config.default_model).strip()
@@ -48,6 +49,6 @@ def build_pipeline(
 
     return B2TPipeline(
         settings=settings,
-        downloader=YtDlpDownloader(),
+        downloader=YtDlpDownloader(cookies_from_browser=cookies_from_browser),
         transcriber=transcriber,
     )

--- a/src/b2t/i18n.py
+++ b/src/b2t/i18n.py
@@ -34,6 +34,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "opt_port_help": "监听端口。",
         "opt_language_help": "语言代码，如 zh-CN、en-US。",
         "opt_source_file_help": "包含批量输入的文本文件，每行一个。",
+        "opt_cookies_from_browser_help": "从浏览器提取登录态 Cookie 以绕过 Bilibili 反爬检测。示例: chrome、firefox、edge、brave，或 firefox:default。",
 
         # ── Runtime messages ─────────────────────────────────
         "missing_dependency": "缺少依赖 '{name}'。{guidance}",
@@ -224,6 +225,7 @@ MESSAGES: dict[str, dict[str, str]] = {
         "opt_port_help": "Bind port.",
         "opt_language_help": "Language code, e.g. zh-CN or en-US.",
         "opt_source_file_help": "Text file containing one batch input per line.",
+        "opt_cookies_from_browser_help": "Extract browser cookies to bypass Bilibili anti-bot protection. e.g. chrome, firefox, edge, brave, or firefox:default.",
 
         # ── Runtime messages ─────────────────────────────────
         "missing_dependency": "Missing dependency '{name}'. {guidance}",

--- a/tests/test_ytdlp_downloader.py
+++ b/tests/test_ytdlp_downloader.py
@@ -124,3 +124,68 @@ def test_ytdlp_options_env_cookie_file_takes_priority(tmp_path, monkeypatch) -> 
     opts = YtDlpDownloader()._build_ydl_opts(source, settings)
 
     assert opts["cookiefile"] == str(env_cookie_file)
+
+
+def test_ytdlp_options_cookies_from_browser_constructor(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("B2T_COOKIES_FROM_BROWSER", raising=False)
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader(cookies_from_browser="chrome")._build_ydl_opts(source, settings)
+
+    assert opts["cookiesfrombrowser"] == ("chrome",)
+
+
+def test_ytdlp_options_cookies_from_browser_env_var(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("B2T_COOKIES_FROM_BROWSER", "firefox")
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert opts["cookiesfrombrowser"] == ("firefox",)
+
+
+def test_ytdlp_options_cookies_from_browser_constructor_overrides_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("B2T_COOKIES_FROM_BROWSER", "firefox")
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader(cookies_from_browser="chrome")._build_ydl_opts(source, settings)
+
+    # Constructor arg takes priority over env var
+    assert opts["cookiesfrombrowser"] == ("chrome",)
+
+
+def test_ytdlp_options_no_cookies_from_browser_by_default(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("B2T_COOKIES_FROM_BROWSER", raising=False)
+    settings = Settings.from_workspace(tmp_path / ".b2t")
+    source = SourceRef(
+        raw_input="BV1xx411c7XD",
+        kind="bilibili",
+        display_name="BV1xx411c7XD",
+        bv="BV1xx411c7XD",
+        url="https://www.bilibili.com/video/BV1xx411c7XD",
+    )
+
+    opts = YtDlpDownloader()._build_ydl_opts(source, settings)
+
+    assert "cookiesfrombrowser" not in opts


### PR DESCRIPTION
- Add -C/--cookies-from-browser CLI flag to tx (transcribe) and batch commands
- Thread through build_pipeline → YtDlpDownloader as constructor arg
- Also support B2T_COOKIES_FROM_BROWSER env var as fallback
- Bump yt-dlp pin to >=2026.6.9 for improved Bilibili WBI bypass
- Add 4 test cases covering constructor, env var, priority, and default